### PR TITLE
Error message for when pin ID's are not unique

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -751,7 +751,7 @@ impl Context {
         let pin_hovered = self.hovered_pin_index == Some(pin_idx) && self.click_interaction_type != ClickInteractionType::BoxSelection;
         let pin_shape = pin.shape;
         let pin_pos = pin.pos;
-        let pin_shape_gui = pin.shape_gui.take().unwrap();
+        let pin_shape_gui = pin.shape_gui.take().expect("Unable to take pin shape. Perhaps your pin id is not unique?");
 
         if pin_hovered {
             self.hovered_pin_flags = pin.flags;


### PR DESCRIPTION
When the pin ID is not unique you get an unwrap error. I spend a fair while trying to chase this down in my test project before I realized the cause (I thought the pin ID just had to be unique per-node). This just adds an error message to the place where rust was panicing.
(And github's web UI causes the EOF newline to vanish).