### PR TITLE
Adjust to support new egui versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_nodes"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Cameron Haigh <cgwhaigh@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ description = "A Egui port of https://github.com/Nelarius/imnodes"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = "0.14"
+egui = "0.16"
 derivative = "2.2.0"
 
 [dev-dependencies]
-eframe = "0.14"
+eframe = "0.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl Context {
         links: impl IntoIterator<Item = (usize, usize, usize, LinkArgs)>,
         ui: &mut egui::Ui,
     ) -> egui::Response {
-        let rect = ui.available_rect_before_wrap_finite();
+        let rect = ui.available_rect_before_wrap();
         self.canvas_rect_screen_space = rect;
         self.canvas_origin_screen_space = self.canvas_rect_screen_space.min.to_vec2();
         {

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,5 +1,6 @@
 use super::*;
 use derivative::Derivative;
+use egui::epaint::PathShape;
 
 /// The Color Style of a Link. If feilds are None then the Context style is used
 #[derive(Default, Debug)]
@@ -178,12 +179,13 @@ impl LinkBezierData {
             )
             .chain(std::iter::once(self.bezier.3))
             .collect();
-        egui::Shape::Path {
+        let path_shape = PathShape{
             points,
             closed: false,
             fill: egui::Color32::TRANSPARENT,
-            stroke: stroke.into(),
-        }
+            stroke: stroke.into()
+        };
+        egui::Shape::Path(path_shape)
     }
 }
 


### PR DESCRIPTION
Some small fixes to make egui_nodes work with the newest egui (e. g. v0.16) versions.