### PR TITLE
Update to egui/eframe v17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_nodes"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Cameron Haigh <cgwhaigh@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_nodes"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Cameron Haigh <cgwhaigh@gmail.com>"]
 edition = "2018"
 license = "MIT"
@@ -9,8 +9,8 @@ description = "A Egui port of https://github.com/Nelarius/imnodes"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = "0.16"
+egui = "0.17.0"
 derivative = "2.2.0"
 
 [dev-dependencies]
-eframe = "0.16"
+eframe = "0.17.0"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -74,7 +74,7 @@ impl epi::App for MyApp {
         "My egui App"
     }
 
-    fn update(&mut self, ctx: &egui::CtxRef, frame: &epi::Frame) {
+    fn update(&mut self, ctx: &egui::Context, frame: &epi::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
             example_graph(&mut self.ctx, &mut self.links, ui);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,9 @@ impl Context {
             );
             {
                 let ui = &mut ui;
+                let rect = ui.ctx().input().screen_rect();
                 ui.set_clip_rect(
-                    self.canvas_rect_screen_space.intersect(ui.ctx().input().screen_rect()),
+                    self.canvas_rect_screen_space.intersect(rect),
                 );
                 ui.painter().rect_filled(
                     self.canvas_rect_screen_space,

--- a/src/link.rs
+++ b/src/link.rs
@@ -75,7 +75,7 @@ impl PartialEq for LinkData {
             std::mem::swap(&mut rhs_start, &mut rhs_end);
         }
 
-        lhs_start == rhs_start && lhs_end == rhs_start
+        lhs_start == rhs_start && lhs_end == rhs_end
     }
 }
 


### PR DESCRIPTION
Thanks for the library.
Not sure if comprehensive update, but at a minimum the example works in what is now latest `egui`/`eframe`

- Change from `CtxRef` to `Context` in example `simple.rs`
- Update `Cargo.toml` version and reference `egui` `"0.17.0"`
- Modify resulting borrow issue in `lib.rs`